### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ English | [简体中文](https://github.com/hongaah/swiftcode-mcp-server/blob/ma
 
 Swiftcode MCP Server is a server based on the Model Context Protocol (MCP), focusing on automated code generation to support modern web development workflows. It can automatically generate TypeScript API clients from Swagger/OpenAPI specifications and quickly generate Vue list page components based on templates, greatly improving frontend and backend development efficiency.
 
+<a href="https://glama.ai/mcp/servers/@hongaah/swiftcode-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hongaah/swiftcode-mcp-server/badge" alt="Swiftcode Server MCP server" />
+</a>
+
 ## Features
 
 - **Swagger/OpenAPI to TypeScript**: Automatically generate TypeScript API clients and type definitions.


### PR DESCRIPTION
This PR adds a badge for the [Swiftcode MCP Server](https://glama.ai/mcp/servers/@hongaah/swiftcode-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hongaah/swiftcode-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hongaah/swiftcode-mcp-server/badge" alt="Swiftcode Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.